### PR TITLE
update `brsmatch()` to work with no never-treated (#3)

### DIFF
--- a/R/brsmatching.R
+++ b/R/brsmatching.R
@@ -155,7 +155,7 @@ compute_distances <- function(df, id = "id", time = "time", trt_time = "trt_time
     trt_time_i <- trt_times[[which(ids == i)]]
     df_at_trt <- df[df[[time]] == trt_time_i, ]
 
-    if(i %in% df_at_trt[[id]]) {
+    if (i %in% df_at_trt[[id]]) {
       covariates_at_trt <- stats::model.matrix(~ 0 + ., data = df_at_trt[, covariates])
       dists <- stats::mahalanobis(covariates_at_trt,
                                   covariates_at_trt[which(df_at_trt[[id]] == i),],
@@ -169,12 +169,13 @@ compute_distances <- function(df, id = "id", time = "time", trt_time = "trt_time
         valid_match <- valid_match & (exist_after_trt | trt_time_i == max(df[[time]]) )
       }
 
-      return(data.frame(
+      out_j <- data.frame(
         trt_id = i,
-        all_id = df_at_trt[[id]][valid_match],
+        all_id = df_at_trt[[id]],
         trt_time = trt_time_i,
-        dist = dists[valid_match]
-      ))
+        dist = dists
+      )
+      return(out_j[valid_match, , drop = FALSE])
     } else {
       return(NULL)
     }

--- a/tests/testthat/test-brsmatching.R
+++ b/tests/testthat/test-brsmatching.R
@@ -264,7 +264,39 @@ test_that("`brsmatch()` returns warning when 'trt_time' is not numeric", {
 })
 
 
+test_that("`brsmatch()` works when there are no never-treated individuals", {
+  df1 <- data.frame(
+    hhidpn = rep(1:5, each = 7),
+    wave = rep(1:7, 5),
+    treatment_time = rep(c(2,3,3,4,7), each = 7),
+    X1 = c(2,2,4,5,5,5,4,
+           9,9,10,10,10,7,7,
+           2,3,4,5,6,6,7,
+           4,5,6,6,6,5,1,
+           3,5,6,6,7,5,6),
+    X2 = rep(c("a","a","b","c","d"), each = 7),
+    X3 = c(9,4,5,6,7,2,3,
+           4,8,5,7,8,5,8,
+           7,4,5,6,7,7,8,
+           4,5,6,7,8,9,7,
+           5,6,7,5,6,5,5),
+    X4 = c(8,9,4,5,6,7,2,
+           3,4,6,4,2,5,7,
+           3,3,4,6,2,4,5,
+           3,5,6,3,4,3,3,
+           3,2,3,3,5,6,3)
+  )
+  df2 <- df1
+  df2[df2$treatment_time == 7, "treatment_time"] <- NA
 
+  pairs <- brsmatch(n_pairs = 2, df = df1, id = "hhidpn", time = "wave",
+                    trt_time = "treatment_time", optimizer = "glpk")
+
+  dist1 <- compute_distances(df1, id = "hhidpn", time = "wave", trt_time = "treatment_time")
+  dist2 <- compute_distances(df2, id = "hhidpn", time = "wave", trt_time = "treatment_time")
+  expect_equal(dist1, dist2)
+
+})
 
 
 


### PR DESCRIPTION
- fixes #3
- update testing to catch this problem
- main problem was `valid_match` would be all false, leading to 0 row data.frame.  Fixed by subsetting after creation.