### PR TITLE
Reduce `n_pairs` in `brsmatch()` when too many are specified

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rsmatch
 Title: Matching Methods for Time-Varying Observational Studies
-Version: 0.2.0.9001
+Version: 0.2.0.9002
 Authors@R: c(
     person("Sean", "Kent", , "skent259@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8697-9069")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rsmatch (development version)
 * Update `brsmatch()` and `coxpsmatch()` to handle NA rows via removing them
+* Fix `brsmatch()` to iteratively reduce the number of pairs if too many are specified
 
 # rsmatch 0.2.0
 

--- a/R/brsmatch.R
+++ b/R/brsmatch.R
@@ -202,8 +202,7 @@ brsmatch <- function(
 
   .print_if(verbose, "Preparing to run optimization model")
   res <- .solve_or_reduce_pairs(n_pairs, model, optimizer, verbose)
-  matches <- switch(
-    optimizer,
+  matches <- switch(optimizer,
     "gurobi" = res$x[grepl("f", model$varnames)],
     "glpk" = res$solution[grepl("f", model$varnames)]
   )
@@ -635,8 +634,10 @@ brsmatch <- function(
 
   if (n_pairs_solve != n_pairs) {
     rlang::warn(
-      paste("Number of pairs reduced from", n_pairs, "to",
-            n_pairs_solve, "to create a solveable model.")
+      paste(
+        "Number of pairs reduced from", n_pairs, "to",
+        n_pairs_solve, "to create a solveable model."
+      )
     )
   }
   return(res)

--- a/R/brsmatch.R
+++ b/R/brsmatch.R
@@ -11,9 +11,9 @@
 #'
 #' Note that when using exact matching, the `n_pairs` are split roughly in
 #' proportion to the number of treated subjects in each exact matching group.
-#' This has a possibility of failing  when `n_pairs` is large.  If this happens
-#' to you, we suggest manually performing exact matching, for example with
-#' `split()`, and selecting `n_pairs` for each group interactively.
+#' If you would like to control `n_pairs` exactly, we suggest manually
+#' performing exact matching, for example with `split()`, and selecting
+#' `n_pairs` for each group interactively.
 #'
 #' @param n_pairs The number of pairs desired from matching.
 #' @param data A data.frame or similar containing columns matching the `id,

--- a/R/brsmatch.R
+++ b/R/brsmatch.R
@@ -201,21 +201,12 @@ brsmatch <- function(
   model <- .rsm_optimization_model(n_pairs, edges, bal, optimizer, verbose, balance)
 
   .print_if(verbose, "Preparing to run optimization model")
-  if (optimizer == "gurobi") {
-    res <- gurobi::gurobi(model, params = list(OutputFlag = 1 * verbose))
-    matches <- res$x[grepl("f", model$varnames)]
-  } else if (optimizer == "glpk") {
-    res <- Rglpk::Rglpk_solve_LP(
-      model$obj,
-      model$mat,
-      model$dir,
-      model$rhs,
-      types = model$types,
-      max = model$max,
-      control = list(verbose = verbose, presolve = TRUE)
-    )
-    matches <- res$solution[grepl("f", model$varnames)]
-  }
+  res <- .solve_or_reduce_pairs(n_pairs, model, optimizer, verbose)
+  matches <- switch(
+    optimizer,
+    "gurobi" = res$x[grepl("f", model$varnames)],
+    "glpk" = res$solution[grepl("f", model$varnames)]
+  )
 
   matched_ids <- edges[matches == 1, c("trt_id", "all_id"), drop = FALSE]
   return(matched_ids)
@@ -591,4 +582,62 @@ brsmatch <- function(
     ))
   }
   return(model)
+}
+
+
+#' Solve brsmatch model even if too many pairs specified
+#'
+#' If the `n_pairs` is too large, the model will be infeasible, and will return
+#' a status code indicating this. This function will iteratively reduce the
+#' number of pairs until the model becomes solvable, then will return the
+#' solution with a warning.
+#'
+#' NOTE: gurobi functionality is untested, as I have since lost my license.
+#' Code is based on the documentation at
+#' https://www.gurobi.com/documentation/current/refman/r_grb.html
+#'
+#' @inheritParams brsmatch
+#' @param model The model output from `.rsm_optimization_model()`
+#'
+#' @return The result from [Rglpk::Rglpk_solve_LP] after possible n_pair
+#'   reduction.
+#'
+#' @noRd
+.solve_or_reduce_pairs <- function(n_pairs, model, optimizer, verbose) {
+  n_pairs_solve <- n_pairs
+
+  while (TRUE) {
+    if (optimizer == "gurobi") {
+      res <- gurobi::gurobi(model, params = list(OutputFlag = 1 * verbose))
+    } else if (optimizer == "glpk") {
+      res <- Rglpk::Rglpk_solve_LP(
+        model$obj,
+        model$mat,
+        model$dir,
+        model$rhs,
+        types = model$types,
+        max = model$max,
+        control = list(verbose = verbose, presolve = TRUE)
+      )
+    }
+    solved <- switch(optimizer,
+      "gurobi" = res$status == "OPTIMAL",
+      "glpk" = res$status == 0,
+    )
+    if (solved) {
+      break
+    }
+
+    n_pairs_solve <- n_pairs_solve - 1
+    # n pairs only appears in the first two model RHS constraints
+    model$rhs[1:2] <- c(n_pairs_solve, -n_pairs_solve)
+  }
+
+  if (n_pairs_solve != n_pairs) {
+    rlang::warn(
+      paste("Number of pairs reduced from", n_pairs, "to",
+            n_pairs_solve, "to create a solveable model.")
+    )
+  }
+  return(res)
 }

--- a/man/brsmatch.Rd
+++ b/man/brsmatch.Rd
@@ -80,9 +80,9 @@ individual is matched to one other individual.
 \details{
 Note that when using exact matching, the \code{n_pairs} are split roughly in
 proportion to the number of treated subjects in each exact matching group.
-This has a possibility of failing  when \code{n_pairs} is large.  If this happens
-to you, we suggest manually performing exact matching, for example with
-\code{split()}, and selecting \code{n_pairs} for each group interactively.
+If you would like to control \code{n_pairs} exactly, we suggest manually
+performing exact matching, for example with \code{split()}, and selecting
+\code{n_pairs} for each group interactively.
 }
 \examples{
 if (requireNamespace("Rglpk", quietly = TRUE)) {

--- a/tests/testthat/test-brsmatch.R
+++ b/tests/testthat/test-brsmatch.R
@@ -442,3 +442,49 @@ test_that("brsmatch works when some input are NA", {
   # can't hold everyone's hand all the time...
 })
 
+
+test_that("brsmatch works when too many pairs specified (#11)", {
+  brsmatch_on_oasis <- function(n_pairs, ...) {
+    brsmatch(
+      n_pairs, oasis,
+      id = "subject_id", time = "visit", trt_time = "time_of_ad",
+      ...
+    )
+  }
+
+  check_for_glpk()
+
+  # With `balance = FALSE`
+  too_many <- brsmatch_on_oasis(n_pairs = 14, balance = FALSE) %>%
+    expect_warning("Number of pairs reduced")
+  enough <- brsmatch_on_oasis(n_pairs = 13, balance = FALSE)
+  expect_equal(too_many, enough)
+
+  # Way too many pairs
+  way_too_many <- brsmatch_on_oasis(n_pairs = 55, balance = FALSE) %>%
+    expect_warning("Number of pairs reduced")
+  expect_equal(way_too_many, too_many)
+
+  # With `balance = TRUE`
+  too_many <- brsmatch_on_oasis(n_pairs = 14, balance = TRUE) %>%
+    expect_warning("Number of pairs reduced")
+  enough <- brsmatch_on_oasis(n_pairs = 13, balance = TRUE)
+  expect_equal(too_many, enough)
+
+  # With `exact_match` variable
+  too_many <- brsmatch_on_oasis(n_pairs = 14, balance = FALSE, exact_match = c("m_f")) %>%
+    expect_warning("Number of pairs reduced")
+  enough <- brsmatch_on_oasis(n_pairs = 13, balance = FALSE, exact_match = c("m_f"))
+  expect_equal(too_many, enough)
+  # The warning message isn't ideal, but its okay for now
+
+
+  # With gurobi
+  check_for_gurobi()
+
+  too_many <- brsmatch_on_oasis(n_pairs = 14, balance = FALSE, options = list(optimizer = "gurobi")) %>%
+    expect_warning("Number of pairs reduced")
+  enough <- brsmatch_on_oasis(n_pairs = 13, balance = FALSE, options = list(optimizer = "gurobi"))
+  expect_equal(too_many, enough)
+
+})


### PR DESCRIPTION
Fixes #11 

This solution will iteratively try the optimization problem with the user-specified `n_pairs`, and check whether the solution is valid. If no solution, `n_pairs` is reduced by one and the problem is attempted again. Repeat until convergence. 

The solution is untested with the Gurobi solver, since my license has lapsed, but the documentation at https://www.gurobi.com/documentation/current/refman/r_grb.html indicates when the solution is found. Tests are added for this case regardless.

We assume that Gurobi and GLPK can quickly determine if a problem is infeasible. If not, this solution could add a lot of run-time, but this is still better than leaving the user with no solution and no warning. 

In an ideal world, the warning would specify which exact match cohort we are working in, but will leave that for future update. 